### PR TITLE
fix: es build to transpile arrow functions and generators

### DIFF
--- a/config/rollup/rollup.config.js
+++ b/config/rollup/rollup.config.js
@@ -23,7 +23,7 @@ function configure(pkg, env, target) {
   const isUmd = target === 'umd'
   const isModule = target === 'module'
   const isCommonJs = target === 'cjs'
-  const pkgFolder = pkg.name.replace('@lilt/', '');
+  const pkgFolder = pkg.name.replace('@lilt/', '')
   const input = `packages/${pkgFolder}/src/index.ts`
   const deps = []
     .concat(pkg.dependencies ? Object.keys(pkg.dependencies) : [])
@@ -83,35 +83,14 @@ function configure(pkg, env, target) {
       include: [`packages/${pkgFolder}/src/**`],
       extensions: ['.js', '.ts', '.tsx'],
       presets: [
+        '@babel/preset-env',
         '@babel/preset-typescript',
-        [
-          '@babel/preset-env',
-          isUmd
-            ? { modules: false }
-            : {
-                exclude: [
-                  '@babel/plugin-transform-regenerator',
-                  '@babel/transform-async-to-generator',
-                ],
-                modules: false,
-                targets: {
-                  esmodules: isModule,
-                },
-              },
-        ],
         '@babel/preset-react',
       ],
       plugins: [
-        [
-          '@babel/plugin-transform-runtime',
-          isUmd
-            ? {}
-            : {
-                regenerator: false,
-                useESModules: isModule,
-              },
-        ],
-        '@babel/plugin-proposal-class-properties',
+        '@babel/plugin-transform-runtime',
+        '@babel/proposal-class-properties',
+        '@babel/plugin-proposal-object-rest-spread',
       ],
     }),
 

--- a/package.json
+++ b/package.json
@@ -81,10 +81,10 @@
     "rollup-plugin-terser": "^5.1.2",
     "rollup-plugin-typescript2": "^0.25.2",
     "rollup-plugin-uglify": "^6.0.3",
-    "slate": "*",
-    "slate-history": "*",
-    "slate-hyperscript": "*",
-    "slate-react": "*",
+    "@lilt/slate": "*",
+    "@lilt/slate-history": "*",
+    "@lilt/slate-hyperscript": "*",
+    "@lilt/slate-react": "*",
     "source-map-loader": "^0.2.4",
     "typescript": "^3.7.2"
   }

--- a/packages/slate-history/package.json
+++ b/packages/slate-history/package.json
@@ -18,11 +18,11 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.58.9",
-    "slate-hyperscript": "^0.58.9"
+    "@lilt/slate": "^0.58.9",
+    "@lilt/slate-hyperscript": "^0.58.9"
   },
   "peerDependencies": {
-    "slate": ">=0.55.0"
+    "@lilt/slate": ">=0.55.0"
   },
   "umdGlobals": {
     "slate": "Slate"

--- a/packages/slate-hyperscript/package.json
+++ b/packages/slate-hyperscript/package.json
@@ -17,10 +17,10 @@
     "is-plain-object": "^3.0.0"
   },
   "devDependencies": {
-    "slate": "^0.58.9"
+    "@lilt/slate": "^0.58.9"
   },
   "peerDependencies": {
-    "slate": ">=0.55.0"
+    "@lilt/slate": ">=0.55.0"
   },
   "umdGlobals": {
     "slate": "Slate"

--- a/packages/slate-react/package.json
+++ b/packages/slate-react/package.json
@@ -23,13 +23,13 @@
     "scroll-into-view-if-needed": "^2.2.20"
   },
   "devDependencies": {
-    "slate": "^0.58.9",
-    "slate-hyperscript": "^0.58.9"
+    "@lilt/slate": "^0.58.9",
+    "@lilt/slate-hyperscript": "^0.58.9"
   },
   "peerDependencies": {
     "react": ">=16.8.0",
     "react-dom": ">=16.8.0",
-    "slate": ">=0.55.0"
+    "@lilt/slate": ">=0.55.0"
   },
   "umdGlobals": {
     "react": "React",


### PR DESCRIPTION
fix es build to use preset-env and regenerator
fix deps to use `@lilt` packages